### PR TITLE
Fixes `location.py` sample for wrong/outdate API

### DIFF
--- a/examples/basics/location.py
+++ b/examples/basics/location.py
@@ -49,7 +49,8 @@ while True:
     print('\tLon: ', lon)
     print('\tEle: ', ele)
     # Send location data to Adafruit IO
-    aio.send_location_data(location.key, lat, lon, ele, value)
+    metadata = { 'lat':lat, 'lon':lon, 'ele':ele, 'created_at':time.asctime(time.gmtime()) }
+    aio.send_data(location.key,value,metadata)
     # shift all values (for test/demo purposes)
     value += 1
     lat -= 0.01


### PR DESCRIPTION
** Scope of change **
Fixes the sample code `example/basics/location.py` which is failing on 
`Traceback (most recent call last):`
`  File "location.py", line 53, in <module>`
`    aio.send_location_data(location.key, lat, lon, ele, value)`
`AttributeError: 'Client' object has no attribute 'send_location_data'`

** what the change does and what parts of the code were modified.** 
Original sample code was using an non-existant API `Client.send_location_data(...)`
This is now replaced with a working call to `Client.send_data(...)` using a metadata dictionnary to provide GPS coordinates and `created_at` timestamp.

** Describe any known limitations with your change.**
Tested only on Raspberry PI with Raspian Stretch lite.
For reference, other modules in the configuration are:
Adafruit-Blinka (1.2.8)
adafruit-io (2.3.2)
Adafruit-PlatformDetect (1.0.0)
Adafruit-PureIO (0.2.3)

** Please run any tests or examples that can exercise your modified code. ** 
The change only applies to one of the sample code.
Doesn't touch the core of Adafruit_IO

Hope this helps.