### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,13 @@ If you have `PIP <https://pip.pypa.io/en/stable/installing/>`_ installed (typica
 
 This will automatically install the Adafruit IO Python client code for your Python scripts to use. You might want to examine the examples folder in this GitHub repository to see examples of usage.
 
+If the above command fails, you may first need to install prerequisites:
+
+.. code-block:: shell
+
+   pip3 install setuptools
+   pip3 install wheel
+
 
 Manual Installation
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add a note about the prerequisite packages needed before pip3 can install adafruit-io

This problem was seen on a fresh system with linuxmint-19.3-cinnamon-64bit/ bionic