### PR TITLE
Fix Testsuite Key

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -28,7 +28,7 @@ class IOTestCase(unittest.TestCase):
         """Return the AIO key specified in the ADAFRUIT_IO_KEY environment
         variable, or raise an exception if it doesn't exist.
         """
-        key = '68163f6f6ee24475b5edb0ed1f77f80a'
+        key = 'aio_YXVY81892EU6NjOl7mCbE0dDCup0'
         if key is None:
             raise RuntimeError("ADAFRUIT_IO_KEY environment variable must be " \
               "set with valid Adafruit IO key to run this test!")
@@ -38,7 +38,7 @@ class IOTestCase(unittest.TestCase):
         """Return the AIO username specified in the ADAFRUIT_IO_USERNAME
         environment variable, or raise an exception if it doesn't exist.
         """
-        username = 'travisiotester'
+        username = 'adafruitiotester'
         if username is None:
             raise RuntimeError("ADAFRUIT_IO_USERNAME environment variable must be " \
               "set with valid Adafruit IO username to run this test!")


### PR DESCRIPTION
Adding back a newly generated test-suite key.

Note: This is not suitable for long-term usage. We should migrate this repository to using Actions instead of Travis and keep both the username and password as secrets in this repo's environment variable instead. https://github.com/adafruit/Adafruit_IO_Python/issues/115