### PR TITLE
copy-and-paste error in batch sending

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -79,7 +79,9 @@ Data can be created after you create a feed, by using the ``send_batch_data(feed
 
     # Create a data items in the 'Test' feed.
     data_list = [Data(value=10), Data(value=11)]
-    aio.create_data('Test', data)
+    # send batch data
+    aio.send_batch_data(temperature.key, data_list)
+
 
 
 Receive Data


### PR DESCRIPTION
The "Send Batch Data" example does not actually contain an "aio.send_batch_data" call.
Fixed it.

