### PR TITLE
Update example, `temp_humidity.py`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,14 @@
 name: Build-CI
 
-on: [pull_request_target, push]
+on:
+    push:
+      branches:
+        - master
 
 jobs:
 
-  approve: # First step
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Approve
-      run: echo For security reasons, all pull requests to this repository need to be approved first before running any automated CI.
-
   build:
     runs-on: ubuntu-latest
-
-    needs: [approve] # Require the first step to finish
     environment:
       name: IO
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: Set up Python
       uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python
       uses: actions/setup-python@v4
-      with:
-        python-version: 3.6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build-CI
 
-on: [pull_request, push]
+on: [pull_request_target, push]
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         SECRET_IO_KEY: ${{ secrets.CI_IO_KEY }}
         SECRET_IO_USER: ${{ secrets.CI_IO_USERNAME }}
       run: |
+        echo "Secret key length: ${#SECRET_IO_KEY}"
+        echo "Secret username length: ${#SECRET_IO_USER}"
         cd tests/
         ADAFRUIT_IO_KEY=$SECRET_IO_KEY ADAFRUIT_IO_USERNAME=$SECRET_IO_USER python -m unittest discover
         cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.6
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'adafruit-io-python'
-copyright = u'2019 Adafruit Industries'
+copyright = u'2023 Adafruit Industries'
 author = u'Adafruit Industries'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -46,7 +46,7 @@ release = u'2.1.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/examples/basics/temp_humidity.py
+++ b/examples/basics/temp_humidity.py
@@ -1,8 +1,7 @@
 """
 'temp_humidity.py'
 ==================================
-Example of sending analog sensor
-values to an Adafruit IO feed.
+Example of sending temperature and humidity data to Adafruit IO
 
 Author(s): Brent Rubell
 
@@ -11,24 +10,27 @@ Tutorial Link: Tutorial Link: https://learn.adafruit.com/adafruit-io-basics-temp
 Dependencies:
     - Adafruit IO Python Client
         (https://github.com/adafruit/io-client-python)
-    - Adafruit_Python_DHT
-        (https://github.com/adafruit/Adafruit_Python_DHT)
+    - Adafruit_CircuitPython_AHTx0
+        (https://github.com/adafruit/Adafruit_CircuitPython_AHTx0)
 """
 
 # import standard python modules.
 import time
 
-# import adafruit dht library.
-import Adafruit_DHT
+# import adafruit-blinka modules
+import board
 
 # import Adafruit IO REST client.
-from Adafruit_IO import Client, Feed
+from Adafruit_IO import Client, Feed, RequestError
 
-# Delay in-between sensor readings, in seconds.
-DHT_READ_TIMEOUT = 5
+# Import AHTx0 library
+import adafruit_ahtx0
 
-# Pin connected to DHT22 data pin
-DHT_DATA_PIN = 26
+# Set true to send tempertaure data in degrees fahrenheit ('f')?
+USE_DEGREES_F = False
+
+# Time between sensor reads, in seconds
+READ_TIMEOUT = 60
 
 # Set to your Adafruit IO key.
 # Remember, your key is a secret,
@@ -42,23 +44,40 @@ ADAFRUIT_IO_USERNAME = 'YOUR_AIO_USERNAME'
 # Create an instance of the REST client.
 aio = Client(ADAFRUIT_IO_USERNAME, ADAFRUIT_IO_KEY)
 
-# Set up Adafruit IO Feeds.
-temperature_feed = aio.feeds('temperature')
-humidity_feed = aio.feeds('humidity')
+# Assign a temperature feed, if one exists already
+try:
+    temperature_feed = aio.feeds('temperature')
+except RequestError: # Doesn't exist, create a new feed
+    feed_temp = Feed(name="temperature")
+    temperature_feed = aio.create_feed(feed_temp)
 
-# Set up DHT22 Sensor.
-dht22_sensor = Adafruit_DHT.DHT22
+# Assign a humidity feed, if one exists already
+try:
+    humidity_feed = aio.feeds('humidity')
+except RequestError: # Doesn't exist, create a new feed
+    feed_humid = Feed(name="humidity")
+    humidity_feed = aio.create_feed(feed_humid)
+
+# Initialize the board's default I2C bus
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# Initialize AHT20 using the default address (0x38) and the board's default i2c bus
+sensor = adafruit_ahtx0.AHTx0(i2c)
 
 while True:
-    humidity, temperature = Adafruit_DHT.read_retry(dht22_sensor, DHT_DATA_PIN)
-    if humidity is not None and temperature is not None:
-        print('Temp={0:0.1f}*C Humidity={1:0.1f}%'.format(temperature, humidity))
-        # Send humidity and temperature feeds to Adafruit IO
-        temperature = '%.2f'%(temperature)
-        humidity = '%.2f'%(humidity)
-        aio.send(temperature_feed.key, str(temperature))
-        aio.send(humidity_feed.key, str(humidity))
+    temperature = sensor.temperature
+    humidity = sensor.relative_humidity
+    if USE_DEGREES_F:
+        temperature = temperature * 9.0 / 5.0 + 32.0
+        print('Temp={0:0.1f}*F'.format(temperature))
     else:
-        print('Failed to get DHT22 Reading, trying again in ', DHT_READ_TIMEOUT, 'seconds')
+        print('Temp={0:0.1f}*C'.format(temperature))
+    print('Humidity={1:0.1f}%'.format(humidity))
+    # Format sensor data as string for sending to Adafruit IO
+    temperature = '%.2f'%(temperature)
+    humidity = '%.2f'%(humidity)
+    # Send humidity and temperature data to Adafruit IO
+    aio.send(temperature_feed.key, str(temperature))
+    aio.send(humidity_feed.key, str(humidity))
+
     # Timeout to avoid flooding Adafruit IO
-    time.sleep(DHT_READ_TIMEOUT)
+    time.sleep(READ_TIMEOUT)


### PR DESCRIPTION
This pull request updates `temp_humidity.py`:

- Updates the example to use the "AHT20 Module - I2C Temperature and Humidity Sensor" instead of the DHT22 (discontinued on Adafruit's web store)
- Updates the example to automatically create feeds, rather than the user manually creating them on Adafruit IO's frontend.
- Adds a user-settable boolean for displaying and sending temperature data in either degrees Fahrenheit or degrees Celsius 
  - Resolves https://github.com/adafruit/Adafruit_IO_Python/issues/141